### PR TITLE
Update Guild Info + Punish

### DIFF
--- a/lib/luro_commands/src/lib.rs
+++ b/lib/luro_commands/src/lib.rs
@@ -5,6 +5,7 @@ use luro_core::Command;
 use luro_e621::e621_commands;
 use luro_furaffinity::furaffinity_commands;
 use luro_songbird::commands::songbird_commands;
+use luro_sled::sled_commands;
 
 mod api;
 mod favs;
@@ -36,5 +37,7 @@ pub fn commands() -> Vec<Command> {
         .chain(testing::commands())
         .chain(luro::commands())
         .chain(favs::fav_commands())
+        .chain(sled_commands())
+
         .collect()
 }

--- a/lib/luro_events/src/lib.rs
+++ b/lib/luro_events/src/lib.rs
@@ -76,11 +76,12 @@ pub async fn ready_listener(ready: &Ready, ctx: &Context) -> Result<(), Error> {
     }
 
     let guild_count = ready.guilds.len();
+    let bot_username = &ready.user.name;
 
     println!("Connected to the Discord API (version {api_version}) with {r_sessions}/{t_sessions} sessions remaining.");
     println!("Connected to and serving a total of {guild_count} guild(s).");
 
-    let presence_string = format!("on {guild_count} guilds | @luro help");
+    let presence_string = format!("on {guild_count} guilds | @{bot_username} help");
     ctx.set_presence(Some(Activity::playing(&presence_string)), OnlineStatus::Online)
         .await;
     Ok(())

--- a/lib/luro_utilities/src/lib.rs
+++ b/lib/luro_utilities/src/lib.rs
@@ -1,24 +1,26 @@
+#![feature(let_chains)]
+
 use itertools::Itertools;
-use poise::serenity_prelude::{Colour, Guild, Role, RoleId};
+use poise::serenity_prelude::{Colour, Guild, RoleId, Role};
 
+/// Get the guild accent colour. If no guild is specified, or we fail to get the highest role, fall back to our defined accent colour
 pub fn guild_accent_colour(accent: [u8; 3], guild: Option<Guild>) -> Colour {
-    if let Some(guild) = &guild {
-        let highest_role = sort_roles(guild).next().expect("No roles in the server, somehow");
-
-        if highest_role.1.colour.0 != 0 {
+    if let Some(guild) = guild {
+        if let Some(highest_role) = sort_roles(&guild).first() && highest_role.1.colour.0 != 0 {
             return highest_role.1.colour;
         };
     };
 
-    Colour::from_rgb(accent[0], accent[1], accent[2])
+    accent_colour(accent)
 }
 
+/// Instead of getting a guild accent colour like in [guild_accent_colour], this function just returns the one from the config, or passed through as a RGB array
 pub fn accent_colour(accent: [u8; 3]) -> Colour {
     Colour::from_rgb(accent[0], accent[1], accent[2])
 }
 
-pub fn sort_roles(guild: &Guild) -> std::vec::IntoIter<(&RoleId, &Role)> {
-    guild.roles.iter().sorted_by_key(|&(_, r)| -r.position)
+pub fn sort_roles(guild: &Guild) -> Vec<(&RoleId, &Role)> {
+    guild.roles.iter().sorted_by_key(|&(_, r)| -r.position).collect::<Vec<_>>()
 }
 
 /// Converts integers to human-readable integers separated by


### PR DESCRIPTION
Guild Info can now run in DMs, and prints out info about the permissions the bot has.

Punish no longer globally matches on `Ban`, now each subcommand is checked for permissions. Owner can bypass.